### PR TITLE
Include all episodes in the RSS feed, not just the last 50

### DIFF
--- a/themes/ado/layouts/rss.xml
+++ b/themes/ado/layouts/rss.xml
@@ -29,7 +29,7 @@
       <itunes:category text="Software How-To" />
       <itunes:category text="Tech News" />
     </itunes:category>
-    {{ range first 50 (where .Site.Pages "Type" "episode") }}
+    {{ range (where .Site.Pages "Type" "episode") }}
     <item>
       <title>{{ title .Title }} - ADO{{ .Params.episode }}</title>
       <itunes:author>Matt Stratton, Trevor Hess, and Bridget Kromhout</itunes:author>


### PR DESCRIPTION
Love the show! I'm a dev guy finishing up my bachelors right now and am probably going to fail because I'm listening to all of the ADO episodes when I should be studying. Just joking. :wink: 

My podcast client doesn't show any of the early episodes since there's a limit on how many episodes are put into the RSS feed. This fix removes that hard limit of 50 episodes in the RSS feed. I don't see any downsides to removing this limit.