### PR TITLE
Remove hardcoded GA tracker

### DIFF
--- a/themes/ado/layouts/partials/google-analytics.html
+++ b/themes/ado/layouts/partials/google-analytics.html
@@ -6,7 +6,7 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', 'UA-45939822-1', 'auto');
+  ga('create', '{{ .Site.Params.GATracker }}', 'auto');
   ga('send', 'pageview');
 
 </script>
@@ -62,7 +62,7 @@ $(document).ready(function() {
 		var text = $(this).text();
 		$(this).click(function(event) { // when someone clicks these links
 			event.preventDefault(); // don't open the link yet
-			if (href.indexOf("arresteddevops.com")==-1) {
+			if (href.indexOf("{{ .Site.Params.social.twitter_domain }}")==-1) {
 				_gaq.push(["_trackEvent", "outbound-links", "Clicked", href, , false]); // create a custom event
 			}
 			setTimeout(function() { // now wait 300 milliseconds...

--- a/themes/ado/layouts/redirect/single.html
+++ b/themes/ado/layouts/redirect/single.html
@@ -4,7 +4,7 @@
 <script type="text/javascript">
 
   var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-45939822-1']);
+  _gaq.push(['_setAccount', '{{ .Site.Params.GATracker }}']);
   _gaq.push(['_trackPageview']);
 
   (function() {

--- a/themes/ado/layouts/sponsor/single.html
+++ b/themes/ado/layouts/sponsor/single.html
@@ -4,7 +4,7 @@
 <script type="text/javascript">
 
   var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-45939822-1']);
+  _gaq.push(['_setAccount', '{{ .Site.Params.GATracker }}']);
   _gaq.push(['_trackPageview']);
 
   (function() {


### PR DESCRIPTION
Removes hardcoded Google Analytics ID, as well as hardcoded domain for show notes links.

Fixes #188