### PR TITLE
Changed twitter share button to be just title

### DIFF
--- a/themes/ado/layouts/partials/share.html
+++ b/themes/ado/layouts/partials/share.html
@@ -1,5 +1,5 @@
 <div class="ssk-group">
     <a href="" class="ssk ssk-facebook"></a>
-    <a href="" class="ssk ssk-twitter"></a>
+    <a href="" class="ssk ssk-twitter" data-text="Episode {{.Params.episode}}"></a>
     <a href="http://www.reddit.com/submit?url={{ .Permalink }}" class="ssk ssk-reddit2"></a>
 </div>


### PR DESCRIPTION
This is super hacky - it has to append the episode number because, something. But it’s better than it was.

Fixes #213