### PR TITLE
Adding episode numbers

### DIFF
--- a/themes/ado/layouts/episode/single.html
+++ b/themes/ado/layouts/episode/single.html
@@ -6,7 +6,7 @@
           </div>
           <div class="col-md-8 col-md-offset-2">
             <div class = "well">
-              <h1>{{ title .Title }} </h1>
+              <h1>{{ title .Title }} (ADO {{ .Params.episode }})</h1>
               {{ .Description | markdownify }}
               <div>
                 {{ partial "share.html" . }}

--- a/themes/ado/layouts/episode/single.html
+++ b/themes/ado/layouts/episode/single.html
@@ -6,7 +6,7 @@
           </div>
           <div class="col-md-8 col-md-offset-2">
             <div class = "well">
-              <h1>{{ title .Title }} (ADO {{ .Params.episode }})</h1>
+              <h1>{{ title .Title }} (ADO{{ .Params.episode }})</h1>
               {{ .Description | markdownify }}
               <div>
                 {{ partial "share.html" . }}

--- a/themes/ado/layouts/index.html
+++ b/themes/ado/layouts/index.html
@@ -57,7 +57,7 @@
               <img src = "/episode/img/{{ .Params.friendly }}.png" class="img-responsive" alt="{{ .Title }}">
               <div class="caption post-content"></div>
               <div class="details">
-                {{ title .Title }} (ADO {{ .Params.episode }})
+                {{ title .Title }} (ADO{{ .Params.episode }})
               </div>
 
             </div>

--- a/themes/ado/layouts/index.html
+++ b/themes/ado/layouts/index.html
@@ -57,7 +57,7 @@
               <img src = "/episode/img/{{ .Params.friendly }}.png" class="img-responsive" alt="{{ .Title }}">
               <div class="caption post-content"></div>
               <div class="details">
-                {{ title .Title }}
+                {{ title .Title }} (ADO {{ .Params.episode }})
               </div>
 
             </div>


### PR DESCRIPTION
This is a proposed change to resolve https://github.com/arresteddevops/ado-hugo/issues/223 and https://github.com/arresteddevops/ado-hugo/issues/222 (simple enough to see if we like how this looks in the preview).

I thought "Episode 32" is too long and "Ep 32" doesn't look as good as "ADO 32", but that's just an opinion and I don't feel strongly about it.

Unanswered question: I'm not sure if/where themes/ado/layouts/episode/list.html is used, so I didn't add this change to that file.