### PR TITLE
Tweak links.

### DIFF
--- a/content/episode/grandpa-paul.md
+++ b/content/episode/grandpa-paul.md
@@ -22,7 +22,8 @@ date = "2017-12-04T04:55:48-05:00"
 * [Bryan Berry’s blog post](https://devopsanywhere.blogspot.com/2014/01/you-should-start-technical-podcast.html)
 * [Live DevOps Call In Show with Dr. Nicole Forsgren](https://www.arresteddevops.com/callinshow/)
 * [@theitskeptic](https://twitter.com/theitskeptic) on Twitter
-* Wardley mapping -  http://blog.gardeviance.org/2015/02/an-introduction-to-wardley-value-chain.html and https://www.nytimes.com/2017/11/25/business/etsy-josh-silverman.html
+* [Wardley mapping introduction](http://blog.gardeviance.org/2015/02/an-introduction-to-wardley-value-chain.html) and [https://twitter.com/swardley](Simon Wardley's) free [Wardley Mapping book](https://medium.com/wardleymaps)
+* [New York Times article on life at Etsy today](https://www.nytimes.com/2017/11/25/business/etsy-josh-silverman.html)
 * [This American Life episode about NUMMI](https://www.thisamericanlife.org/radio-archives/episode/561/nummi-2015)
 * [DOES17 San Francisco - How Your Systems Keep Running Day After Day - John Allspaw](https://www.youtube.com/watch?v=xA5U85LSk0M)
 * [The Ship Show - Extinguishing Burnout](http://theshipshow.com/2016/03/extinguishing-burnout/)


### PR DESCRIPTION
Fixes the NY times link (it's not related to Wardley Maps) and links a couple of other Wardley Map resources.