### PR TITLE
Fixes #335 - Removed broken store link

### DIFF
--- a/themes/ado/layouts/partials/header.html
+++ b/themes/ado/layouts/partials/header.html
@@ -32,10 +32,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                   <li><a href="/books">Books</a></li>
                 </ul>
               </li>
-              <li><a href = "/bananastand">Subscribe to Newsletter</a></li>
-              <li><a href = "/faq">ADO FAQ</a></li>
+        <li><a href = "/bananastand">Subscribe to Newsletter</a></li>
+        <li><a href = "/faq">ADO FAQ</a></li>
         <li><a href = "/thanks-pals">ADO Supporters</a></li>
-              <li><a href = "http://store.arresteddevops.com">ADO Products</a></li>
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li>


### PR DESCRIPTION
If store.ado.com is meant to feel free to close this PR :)

*Fluff* - Also fixed alignment of other `<li>` elements.