### PR TITLE
Fix path for docker compose

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
 	"dockerComposeFile": [
-		"..\\docker-compose.yml",
+		"../docker-compose.yml",
 		"docker-compose.yml"
 	],
 	// The 'service' property is the name of the service for the container that VS Code should


### PR DESCRIPTION
The previous path did not work on MacOS. This change works; I would like to have Jessica check it out since I don't know what platform this was working on before and if there will be an issue.

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>